### PR TITLE
Grape Swagger & Entity Integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,15 @@ gem 'activeadmin'
 gem 'kaminari'
 gem 'api-pagination'
 
+# Grape API
+gem 'grape', '~> 1'
+gem 'grape-entity'
+gem 'hashie-forbidden_attributes'
+gem 'grape-swagger'
+gem 'grape-swagger-entity'
+gem 'grape-swagger-rails'
+gem 'grape-middleware-logger'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,10 @@ GEM
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (8.0.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.11)
     bindex (0.5.0)
     binding_of_caller (0.7.3)
@@ -94,6 +98,8 @@ GEM
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -108,6 +114,8 @@ GEM
       after_commit_action (~> 1.0)
     crass (1.0.2)
     debug_inspector (0.0.3)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -127,6 +135,7 @@ GEM
       activemodel-serializers-xml (~> 1.0)
       activesupport (~> 5.0)
       request_store (~> 1.0)
+    equalizer (0.0.11)
     erb2haml (0.1.5)
       html2haml
     erubi (1.7.0)
@@ -302,6 +311,25 @@ GEM
     formtastic_i18n (0.6.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    grape (1.0.1)
+      activesupport
+      builder
+      mustermann-grape (~> 1.0.0)
+      rack (>= 1.3.0)
+      rack-accept
+      virtus (>= 1.0.0)
+    grape-entity (0.6.1)
+      activesupport (>= 5.0.0)
+      multi_json (>= 1.3.2)
+    grape-middleware-logger (1.9.0)
+      grape (>= 0.17, < 1.1)
+    grape-swagger (0.27.3)
+      grape (>= 0.16.2)
+    grape-swagger-entity (0.2.2)
+      grape-entity (>= 0.5.0)
+      grape-swagger (>= 0.20.4)
+    grape-swagger-rails (0.3.0)
+      railties (>= 3.2.12)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -315,6 +343,8 @@ GEM
       actionpack (>= 4.1, < 5.2)
       activesupport (>= 4.1, < 5.2)
     hashie (3.5.6)
+    hashie-forbidden_attributes (0.1.1)
+      hashie (>= 3.0)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -324,6 +354,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.0)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     inflecto (0.0.2)
     inherited_resources (1.7.2)
       actionpack (>= 3.2, < 5.2.x)
@@ -368,6 +399,9 @@ GEM
     multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mustermann (1.0.1)
+    mustermann-grape (1.0.0)
+      mustermann (~> 1.0.0)
     mysql2 (0.4.9)
     netrc (0.11.0)
     nio4r (2.1.0)
@@ -407,6 +441,8 @@ GEM
     public_suffix (3.0.0)
     puma (3.10.0)
     rack (2.0.3)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rails (5.1.4)
@@ -526,6 +562,11 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     uniform_notifier (1.10.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -563,7 +604,14 @@ DEPENDENCIES
   factory_bot_rails
   faker
   fog
+  grape (~> 1)
+  grape-entity
+  grape-middleware-logger
+  grape-swagger
+  grape-swagger-entity
+  grape-swagger-rails
   haml-rails
+  hashie-forbidden_attributes
   kaminari
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.3.18, < 0.5)

--- a/app/api/api_components/controllers/api_controller.rb
+++ b/app/api/api_components/controllers/api_controller.rb
@@ -1,0 +1,7 @@
+module APIComponents
+  module Controllers
+    class ApiController < Grape::API
+
+    end
+  end
+end

--- a/app/api/api_components/controllers/circle/overview.rb
+++ b/app/api/api_components/controllers/circle/overview.rb
@@ -4,15 +4,21 @@ module APIComponents
       class Overview < ApiController
         desc 'Get public profile for specified company' do
           detail <<~DETAIL
-              Get a profile for a professional who has the same id as the given param id.
+              Get a overview for a circle who has the same id as the given param id.
           DETAIL
           http_codes([
-            { code: 200, message: 'Professional', model: Entities::Circle::Overview }
+            { code: 200, message: 'circle', model: Entities::Circle::Overview }
           ])
         end
 
         params do
-          requires :id, type: Integer, description: 'the id of the professional'
+          requires :id, type: Integer, description: 'the id of the circle'
+        end
+
+        get '/:id/circle' do
+          circle = Circle.find(params[:id])
+
+          present circle, Entities::Circle::Overview
         end
       end
     end

--- a/app/api/api_components/controllers/circle/overview.rb
+++ b/app/api/api_components/controllers/circle/overview.rb
@@ -17,8 +17,7 @@ module APIComponents
 
         get '/:id' do
           circle = ::Circle.find(params[:id])
-
-          present circle, Entities::Circle::Overview
+          present circle, with: Entities::Circle::Overview
         end
       end
     end

--- a/app/api/api_components/controllers/circle/overview.rb
+++ b/app/api/api_components/controllers/circle/overview.rb
@@ -1,0 +1,20 @@
+module APIComponents
+  module Controllers
+    module Circle
+      class Overview < ApiController
+        desc 'Get public profile for specified company' do
+          detail <<~DETAIL
+              Get a profile for a professional who has the same id as the given param id.
+          DETAIL
+          http_codes([
+            { code: 200, message: 'Professional', model: Entities::Circle::Overview }
+          ])
+        end
+
+        params do
+          requires :id, type: Integer, description: 'the id of the professional'
+        end
+      end
+    end
+  end
+end

--- a/app/api/api_components/controllers/circle/overview.rb
+++ b/app/api/api_components/controllers/circle/overview.rb
@@ -15,8 +15,8 @@ module APIComponents
           requires :id, type: Integer, description: 'the id of the circle'
         end
 
-        get '/:id/circle' do
-          circle = Circle.find(params[:id])
+        get '/:id' do
+          circle = ::Circle.find(params[:id])
 
           present circle, Entities::Circle::Overview
         end

--- a/app/api/api_components/entities/circle.rb
+++ b/app/api/api_components/entities/circle.rb
@@ -2,7 +2,13 @@ module APIComponents
   module Entities
     module Circle
       class Overview < Grape::Entity
+        expose :id
+        expose :university_name
         expose :name
+        expose :description
+        expose :members_count
+        expose :bands_count
+        expose :created_at
       end
     end
   end

--- a/app/api/api_components/entities/circle.rb
+++ b/app/api/api_components/entities/circle.rb
@@ -1,0 +1,9 @@
+module APIComponents
+  module Entities
+    module Circle
+      class Overview < Grape::Entity
+        expose :name
+      end
+    end
+  end
+end

--- a/app/api/api_root.rb
+++ b/app/api/api_root.rb
@@ -1,22 +1,16 @@
 require 'grape-swagger'
 
 class APIRoot < Grape::API
+  version 'v1'
   format :json
   prefix :api
-
-  add_swagger_documentation(
-    hide_documentation_path: false,
-    doc_version: 'Document 0.0',
-    info: {
-        title: 'AMIRY',
-        description: 'AMIRY API'
-    }
-  )
 
   namespace :circle do
     namespace :overview do
       mount APIComponents::Controllers::Circle::Overview
     end
   end
+
+  add_swagger_documentation
 
 end

--- a/app/api/api_root.rb
+++ b/app/api/api_root.rb
@@ -8,8 +8,8 @@ class APIRoot < Grape::API
     hide_documentation_path: false,
     doc_version: 'Document 0.0',
     info: {
-        title: 'Black Thunder',
-        description: 'Black Thunder API'
+        title: 'AMIRY',
+        description: 'AMIRY API'
     }
   )
 

--- a/app/api/api_root.rb
+++ b/app/api/api_root.rb
@@ -2,7 +2,7 @@ require 'grape-swagger'
 
 class APIRoot < Grape::API
   format :json
-  # prefix :api
+  prefix :api
 
   add_swagger_documentation(
     hide_documentation_path: false,

--- a/app/api/api_root.rb
+++ b/app/api/api_root.rb
@@ -1,0 +1,22 @@
+require 'grape-swagger'
+
+class APIRoot < Grape::API
+  format :json
+  # prefix :api
+
+  add_swagger_documentation(
+    hide_documentation_path: false,
+    doc_version: 'Document 0.0',
+    info: {
+        title: 'Black Thunder',
+        description: 'Black Thunder API'
+    }
+  )
+
+  namespace :circle do
+    namespace :overview do
+      mount APIComponents::Controllers::Circle::Overview
+    end
+  end
+
+end

--- a/app/models/circle.rb
+++ b/app/models/circle.rb
@@ -30,4 +30,8 @@ class Circle < ApplicationRecord
             :members_count, :university_id, numericality: true
   validates :name,                          uniqueness: { scope: :university_id }
 
+  def university_name
+    self.university.name
+  end
+
 end

--- a/config/initializers/grape.rb
+++ b/config/initializers/grape.rb
@@ -1,0 +1,3 @@
+# Configuration for Grape
+Rails.application.config.paths.add File.join('app', 'api'), glob: File.join('**', '*.rb')
+Rails.application.config.autoload_paths += Dir[Rails.root.join('app', 'api', '**')]

--- a/config/initializers/swagger.rb
+++ b/config/initializers/swagger.rb
@@ -1,0 +1,4 @@
+GrapeSwaggerRails.options.before_action do |request|
+  GrapeSwaggerRails.options.app_url = request.protocol + request.host_with_port
+end
+GrapeSwaggerRails.options.app_name = 'AMIRY'

--- a/config/initializers/swagger.rb
+++ b/config/initializers/swagger.rb
@@ -1,3 +1,4 @@
+GrapeSwaggerRails.options.url = '/api/v1/swagger_doc'
 GrapeSwaggerRails.options.before_action do |request|
   GrapeSwaggerRails.options.app_url = request.protocol + request.host_with_port
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   mount APIRoot => '/'
-  mount GrapeSwaggerRails::Engine => '/docs'
+  mount GrapeSwaggerRails::Engine => '/api-spec'
 
   resources :circles, only: :index
   resources :articles, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,13 @@
 Rails.application.routes.draw do
+
   devise_for :admin_users, ActiveAdmin::Devise.config
+
   ActiveAdmin.routes(self)
 
   devise_for :users
+
+  mount APIRoot => '/'
+  mount GrapeSwaggerRails::Engine => '/docs'
 
   resources :circles, only: :index
   resources :articles, only: :index


### PR DESCRIPTION
## WHY
 - フロント側との連携で、リアルタイムでAPI変更などを知るためにgrapeのswagger-documentを使うため

## WHAT
 - `grape` 関連のgemをインストール。
 - `route.rb` で、Grapeのルートなどをマウントさせた。

## ISSUE
 - getのエンドポイントがgrapeのswagger docsで表示されない。

## ISSUE SOLVED 
 - `swagger.rb` に `GrapeSwaggerRails.options.url = '/api/v1/swagger_doc` がなかったため。