### PR TITLE
Amazon S3 Upload

### DIFF
--- a/app/api/api_components/controllers/lives_controller.rb
+++ b/app/api/api_components/controllers/lives_controller.rb
@@ -42,16 +42,18 @@ module APIComponents
         requires :name,        type: String,   desc: 'The name of the live.'
         requires :description, type: String,   desc: 'The description of the live.'
         requires :hold_at,     type: DateTime, desc: 'When the live is to be held at.'
+        optional :image_file,  type: File,     desc: 'The image files for the live.'
       end
       post '/' do
         live = Live.new(name: params[:name], description: params[:description], hold_at: params[:hold_at])
         live.circle = Circle.find_by(id: params[:circle_id])
+        live.live_images.build(name: params[:image_file])
         begin
           live.save!
+          present live, with: Entities::Live
         rescue => error
           Errors::InternalServerError.new(message: error.message)
         end
-        present live, with: Entities::Live
       end
     end
   end

--- a/app/api/api_components/entities/live.rb
+++ b/app/api/api_components/entities/live.rb
@@ -1,6 +1,5 @@
 module APIComponents
   module Entities
-    # Exposed properties in Live model
     class Live < Grape::Entity
       expose :id,                  documentation: { required: true, type: 'Integer', desc: 'The primary id of the circle.' }
       expose :circle_name,         documentation: { required: true, type: 'String',  desc: 'The name of the circle where a live is to be held.' }
@@ -9,6 +8,7 @@ module APIComponents
       expose :reservations_count,  documentation: { required: true, type: 'Integer', desc: 'The reservations count for the live.' }
       expose :hold_at,             documentation: { required: true, type: 'String',  desc: 'When the live is to be held at.' }
       expose :available_seats_num, documentation: { required: true, type: 'Integer', desc: 'The number of available seats.' }
+      expose :image_urls,          documentation: { required: true, type: 'String',  desc: 'The urls of the images for the live.', is_array: true }
     end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -12,25 +12,33 @@
 #
 
 class Article < ApplicationRecord
-  # Constant
+  # Pagination
   paginates_per 15
 
   # Scope
   scope :in_newest_order, -> { order(created_at: :desc) }
 
   # Association
-  belongs_to :user, optional: true
+  belongs_to :user
   has_many   :article_comments
+  has_many   :article_files
 
   # Validation
-  validates :content, :user_id, presence: true
-  validates :user_id,           numericality: true
+  validates :title, :content,
+            :user_id,         presence: true
+  validates :user_id,         numericality: { only_integer: true }
 
-  def created_by?(user)
-    self.user_id == user.id
-  end
-
+  # Getter Methods
   def author_name
     self.user&.display_name.to_s
+  end
+
+  def file_urls
+    self.article_files.map(&:file_url)
+  end
+
+  # Checker Methods
+  def created_by?(user)
+    self.user_id == user.id
   end
 end

--- a/app/models/article_file.rb
+++ b/app/models/article_file.rb
@@ -11,9 +11,16 @@
 #
 
 class ArticleFile < ApplicationRecord
+  # Mix-in
+  include FileModelInterface
+
   # Validation
   validates :user_id, :article_id, numericality: { only_integer: true }, presence: true
 
   # Uploader
   mount_uploader :name, ArticleFileUploader
+  
+  def file_url
+    "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.name.file.filename}"
+  end
 end

--- a/app/models/article_file.rb
+++ b/app/models/article_file.rb
@@ -19,8 +19,4 @@ class ArticleFile < ApplicationRecord
 
   # Uploader
   mount_uploader :name, ArticleFileUploader
-  
-  def file_url
-    "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.name.file.filename}"
-  end
 end

--- a/app/models/band.rb
+++ b/app/models/band.rb
@@ -54,6 +54,10 @@ class Band < ApplicationRecord
     self.intercollege?
   end
 
+  def image_urls
+    self.band_images.map(&:file_url)
+  end
+
   # Setter Methods
   def set_emtpy_string_in_blank_description
     self.description = '' if self.description.blank?

--- a/app/models/band_image.rb
+++ b/app/models/band_image.rb
@@ -10,9 +10,17 @@
 #
 
 class BandImage < ApplicationRecord
+  # Mix-in
+  include FileModelInterface
+
   # Association
   belongs_to :band
 
   # Uploader
   mount_uploader :name, BandImageUploader
+
+  # Getter Method
+  def image_url
+    "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.name.file.filename}"
+  end
 end

--- a/app/models/band_image.rb
+++ b/app/models/band_image.rb
@@ -18,9 +18,4 @@ class BandImage < ApplicationRecord
 
   # Uploader
   mount_uploader :name, BandImageUploader
-
-  # Getter Method
-  def image_url
-    "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.name.file.filename}"
-  end
 end

--- a/app/models/circle.rb
+++ b/app/models/circle.rb
@@ -34,4 +34,8 @@ class Circle < ApplicationRecord
   def university_name
     self.university&.name.to_s
   end
+
+  def image_urls
+    self.circle_images.map(&:file_url)
+  end
 end

--- a/app/models/circle_image.rb
+++ b/app/models/circle_image.rb
@@ -25,8 +25,4 @@ class CircleImage < ApplicationRecord
 
   # Uploader
   mount_uploaders :name, CircleImageUploader
-
-  def file_url
-    "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.name.file.filename}"
-  end
 end

--- a/app/models/circle_image.rb
+++ b/app/models/circle_image.rb
@@ -11,6 +11,9 @@
 #
 
 class CircleImage < ApplicationRecord
+  # Mix-in
+  include FileModelInterface
+
   # Needs this line because the table has a column named "type"
   self.inheritance_column = :_type_disabled
 
@@ -22,4 +25,8 @@ class CircleImage < ApplicationRecord
 
   # Uploader
   mount_uploaders :name, CircleImageUploader
+
+  def file_url
+    "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.name.file.filename}"
+  end
 end

--- a/app/models/concerns/file_model_interface.rb
+++ b/app/models/concerns/file_model_interface.rb
@@ -1,4 +1,4 @@
-module S3Storage
+module FileModelInterface
   extend ActiveSupport::Concern
 
   included do
@@ -12,7 +12,7 @@ module S3Storage
       end
     end
 
-    def image_url
+    def file_url
       raise NotImplementedError.new("You must implement #{self.class}##{__method__}")
     end
   end

--- a/app/models/concerns/file_model_interface.rb
+++ b/app/models/concerns/file_model_interface.rb
@@ -8,16 +8,16 @@ module FileModelInterface
     # Getter Methods
     def s3_directory
       case Rails.env
-        when 'production'; 'amiry-production'
-        when 'staging'; 'amiry-staging'
-        when 'development'; 'amiry-development'
-        when 'test'; 'amiry-development'
-        else 'amiry-development'
+      when 'production'  then 'amiry-production'
+      when 'staging'     then 'amiry-staging'
+      when 'development' then 'amiry-development'
+      when 'test';       then 'amiry-development'
+      else 'amiry-development'
       end
     end
 
     def file_url
-      "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.class.to_s}/#{self.name.file.filename}"
+      "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.class}/#{self.name.file.filename}"
     end
   end
 end

--- a/app/models/concerns/file_model_interface.rb
+++ b/app/models/concerns/file_model_interface.rb
@@ -2,6 +2,10 @@ module FileModelInterface
   extend ActiveSupport::Concern
 
   included do
+    # Constant
+    AMAZON_S3_DOMAIN = 'https://s3-ap-northeast-1.amazonaws.com'
+
+    # Getter Methods
     def s3_directory
       case Rails.env
         when 'production'; 'amiry-production'
@@ -13,7 +17,7 @@ module FileModelInterface
     end
 
     def file_url
-      raise NotImplementedError.new("You must implement #{self.class}##{__method__}")
+      "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.class.to_s}/#{self.name.file.filename}"
     end
   end
 end

--- a/app/models/concerns/s3_storage.rb
+++ b/app/models/concerns/s3_storage.rb
@@ -1,0 +1,19 @@
+module S3Storage
+  extend ActiveSupport::Concern
+
+  included do
+    def s3_directory
+      case Rails.env
+        when 'production'; 'amiry-production'
+        when 'staging'; 'amiry-staging'
+        when 'development'; 'amiry-development'
+        when 'test'; 'amiry-development'
+        else 'amiry-development'
+      end
+    end
+
+    def image_url
+      raise NotImplementedError.new("You must implement #{self.class}##{__method__}")
+    end
+  end
+end

--- a/app/models/lecture.rb
+++ b/app/models/lecture.rb
@@ -14,7 +14,7 @@
 
 class Lecture < ApplicationRecord
   # Callback Methods
-  before_save :set_description_empty, if: :new_record?
+  before_save :set_empty_string_in_blank_description, if: :new_record?
 
   # Pagination
   paginates_per 10
@@ -25,19 +25,25 @@ class Lecture < ApplicationRecord
 
   # Association
   belongs_to :user
+  has_many   :lecture_files
 
   # Validation
-  validates :user_id, :description,
-            :address, :hold_at,     presence: true
-  validates :user_id,               numericality: true
+  validates :user_id, :title,
+            :description, :address,
+            :hold_at,               presence: true
+  validates :user_id,               numericality: { only_integer: true }
 
   # Getter Methods
   def holder_name
     self.user&.display_name.to_s
   end
 
+  def file_urls
+    self.lecture_files.map(&:file_url)
+  end
+
   # Setter Methods
-  def set_description_empty
+  def set_empty_string_in_blank_description
     self.description = '' if self.description.blank?
   end
 end

--- a/app/models/lecture_file.rb
+++ b/app/models/lecture_file.rb
@@ -14,9 +14,6 @@ class LectureFile < ApplicationRecord
   # Mix-in
   include FileModelInterface
 
-  # Constant
-  AMAZON_S3_DOMAIN = 'https://s3-ap-northeast-1.amazonaws.com'
-
   # Association
   belongs_to :user
   belongs_to :lecture
@@ -26,9 +23,4 @@ class LectureFile < ApplicationRecord
 
   # Uploader
   mount_uploader :name, LectureFileUploader
-
-  def file_url
-    "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.name.file.filename}"
-  end
-
 end

--- a/app/models/lecture_file.rb
+++ b/app/models/lecture_file.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: lecture_files
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer          unsigned, not null
+#  lecture_id :integer          unsigned, not null
+#  name       :string(255)      default(""), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class LectureFile < ApplicationRecord
+  # Mix-in
+  include FileModelInterface
+
+  # Constant
+  AMAZON_S3_DOMAIN = 'https://s3-ap-northeast-1.amazonaws.com'
+
+  # Association
+  belongs_to :user
+  belongs_to :lecture
+
+  # Validation
+  validates :user_id, :lecture_id, presence: true, numericality: { only_integer: true }
+
+  # Uploader
+  mount_uploader :name, LectureFileUploader
+
+  def file_url
+    "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.name.file.filename}"
+  end
+
+end

--- a/app/models/live.rb
+++ b/app/models/live.rb
@@ -27,11 +27,12 @@ class Live < ApplicationRecord
   scope :recent,  -> { order(hold_at: :desc) }
 
   # Association
-  belongs_to :circle,    optional: true
+  belongs_to :circle,     optional: true
   has_many   :band_lives
   has_many   :user_lives
-  has_many   :bands,     through: :band_lives
-  has_many   :users,     through: :user_lives
+  has_many   :bands,      through: :band_lives
+  has_many   :users,      through: :user_lives
+  has_many   :live_images
 
   # Validation
   validates :name, :hold_at, :description,
@@ -48,6 +49,10 @@ class Live < ApplicationRecord
 
   def available_seats_num
     self.max_capacity - self.reservations_count
+  end
+
+  def image_urls
+    self.live_images.map(&:file_url)
   end
 
   # Setter Methods

--- a/app/models/live_image.rb
+++ b/app/models/live_image.rb
@@ -13,17 +13,9 @@ class LiveImage < ApplicationRecord
   # Mix-in
   include FileModelInterface
 
-  # Constant
-  AMAZON_S3_DOMAIN = 'https://s3-ap-northeast-1.amazonaws.com'
-
   # Association
   belongs_to :live
 
   # Uploader
   mount_uploader :name, LiveImageUploader
-
-  # Getter Methods
-  def file_url
-    "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.name.file.filename}"
-  end
 end

--- a/app/models/live_image.rb
+++ b/app/models/live_image.rb
@@ -10,9 +10,20 @@
 #
 
 class LiveImage < ApplicationRecord
+  # Mix-in
+  include FileModelInterface
+
+  # Constant
+  AMAZON_S3_DOMAIN = 'https://s3-ap-northeast-1.amazonaws.com'
+
   # Association
   belongs_to :live
 
   # Uploader
-  mount_uploaders :name, LiveImageUploader
+  mount_uploader :name, LiveImageUploader
+
+  # Getter Methods
+  def file_url
+    "#{AMAZON_S3_DOMAIN}/#{self.s3_directory}/#{self.name.file.filename}"
+  end
 end

--- a/app/uploaders/article_file_uploader.rb
+++ b/app/uploaders/article_file_uploader.rb
@@ -1,50 +1,9 @@
-class ArticleFileUploader < CarrierWave::Uploader::Base
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
-
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
+class ArticleFileUploader < BaseUploader
   def store_dir
     model.class.to_s
   end
 
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url(*args)
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-  # end
-
-  # Process files as they are uploaded:
-  # process scale: [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
-
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
   def extension_whitelist
     %w(jpg jpeg png pdf)
-  end
-
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  def filename
-    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
-  end
-
-  protected
-
-  def secure_token(length)
-    var = :"@#{mounted_as}_secure_token"
-    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
   end
 end

--- a/app/uploaders/article_file_uploader.rb
+++ b/app/uploaders/article_file_uploader.rb
@@ -37,7 +37,14 @@ class ArticleFileUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def filename
+    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
+  end
+
+  protected
+
+  def secure_token(length)
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
+  end
 end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -29,7 +29,14 @@ class AvatarUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def filename
+    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
+  end
+
+  protected
+
+  def secure_token(length)
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
+  end
 end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,42 +1,9 @@
-class AvatarUploader < CarrierWave::Uploader::Base
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
-
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
+class AvatarUploader < BaseUploader
   def store_dir
     model.class.to_s
   end
 
-  # Process files as they are uploaded:
-  # process scale: [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
-
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
   def extension_whitelist
     %w(jpg jpeg gif png)
-  end
-
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  def filename
-    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
-  end
-
-  protected
-
-  def secure_token(length)
-    var = :"@#{mounted_as}_secure_token"
-    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
   end
 end

--- a/app/uploaders/band_image_uploader.rb
+++ b/app/uploaders/band_image_uploader.rb
@@ -17,7 +17,14 @@ class BandImageUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def filename
+    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
+  end
+
+  protected
+
+  def secure_token(length)
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
+  end
 end

--- a/app/uploaders/band_image_uploader.rb
+++ b/app/uploaders/band_image_uploader.rb
@@ -1,30 +1,9 @@
-class BandImageUploader < CarrierWave::Uploader::Base
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
-
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
+class BandImageUploader < BaseUploader
   def store_dir
     model.class.to_s
   end
 
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
   def extension_whitelist
     %w(jpg jpeg gif png)
-  end
-
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  def filename
-    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
-  end
-
-  protected
-
-  def secure_token(length)
-    var = :"@#{mounted_as}_secure_token"
-    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
   end
 end

--- a/app/uploaders/base_uploader.rb
+++ b/app/uploaders/base_uploader.rb
@@ -9,7 +9,7 @@ class BaseUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    raise NotImplementedError.new("You must implement #{self.class}##{__method__}")
+    raise NotImplementedError, "You must implement #{self.class}##{__method__}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
@@ -35,7 +35,7 @@ class BaseUploader < CarrierWave::Uploader::Base
   # Add a white list of extengsions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_whitelist
-    raise NotImplementedError.new("You must implement #{self.class}##{__method__}")
+    raise NotImplementedError, "You must implement #{self.class}##{__method__}"
   end
 
   # Override the filename of the uploaded files:
@@ -48,6 +48,6 @@ class BaseUploader < CarrierWave::Uploader::Base
 
   def secure_token(length)
     var = :"@#{mounted_as}_secure_token"
-    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
+    model.instance_variable_get(var) || model.instance_variable_set(var, SecureRandom.hex(length / 2))
   end
 end

--- a/app/uploaders/base_uploader.rb
+++ b/app/uploaders/base_uploader.rb
@@ -1,0 +1,53 @@
+class BaseUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    raise NotImplementedError.new("You must implement #{self.class}##{__method__}")
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extengsions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_whitelist
+    raise NotImplementedError.new("You must implement #{self.class}##{__method__}")
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  def filename
+    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
+  end
+
+  protected
+
+  def secure_token(length)
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
+  end
+end

--- a/app/uploaders/circle_image_uploader.rb
+++ b/app/uploaders/circle_image_uploader.rb
@@ -17,7 +17,14 @@ class CircleImageUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def filename
+    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
+  end
+
+  protected
+
+  def secure_token(length)
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
+  end
 end

--- a/app/uploaders/circle_image_uploader.rb
+++ b/app/uploaders/circle_image_uploader.rb
@@ -1,30 +1,9 @@
-class CircleImageUploader < CarrierWave::Uploader::Base
-  # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
-
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
+class CircleImageUploader < BaseUploader
   def store_dir
     model.class.to_s
   end
 
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
   def extension_whitelist
     %w(jpg jpeg gif png)
-  end
-
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  def filename
-    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
-  end
-
-  protected
-
-  def secure_token(length)
-    var = :"@#{mounted_as}_secure_token"
-    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
   end
 end

--- a/app/uploaders/lecture_file_uploader.rb
+++ b/app/uploaders/lecture_file_uploader.rb
@@ -1,0 +1,55 @@
+class LectureFileUploader < CarrierWave::Uploader::Base
+
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  # storage :file
+  storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    model.class.to_s
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extengsions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_whitelist
+    %w(jpg jpeg png pdf)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  def filename
+    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
+  end
+
+  protected
+
+  def secure_token(length)
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
+  end
+end

--- a/app/uploaders/lecture_file_uploader.rb
+++ b/app/uploaders/lecture_file_uploader.rb
@@ -1,55 +1,9 @@
-class LectureFileUploader < CarrierWave::Uploader::Base
-
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
-
-  # Choose what kind of storage to use for this uploader:
-  # storage :file
-  storage :fog
-
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
+class LectureFileUploader < BaseUploader
   def store_dir
     model.class.to_s
   end
 
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url(*args)
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-  # end
-
-  # Process files as they are uploaded:
-  # process scale: [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
-
-  # Add a white list of extengsions which are allowed to be uploaded.
-  # For images you might use something like this:
   def extension_whitelist
     %w(jpg jpeg png pdf)
-  end
-
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  def filename
-    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
-  end
-
-  protected
-
-  def secure_token(length)
-    var = :"@#{mounted_as}_secure_token"
-    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
   end
 end

--- a/app/uploaders/live_image_uploader.rb
+++ b/app/uploaders/live_image_uploader.rb
@@ -4,8 +4,8 @@ class LiveImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -21,7 +21,14 @@ class LiveImageUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def filename
+    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
+  end
+
+  protected
+
+  def secure_token(length)
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
+  end
 end

--- a/app/uploaders/live_image_uploader.rb
+++ b/app/uploaders/live_image_uploader.rb
@@ -1,34 +1,9 @@
-class LiveImageUploader < CarrierWave::Uploader::Base
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
-
-  # Choose what kind of storage to use for this uploader:
-  # storage :file
-  storage :fog
-
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
+class LiveImageUploader < BaseUploader
   def store_dir
     model.class.to_s
   end
 
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
   def extension_whitelist
     %w(jpg jpeg gif png)
-  end
-
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  def filename
-    "#{secure_token(10)}.#{file.extension}" if original_filename.present?
-  end
-
-  protected
-
-  def secure_token(length)
-    var = :"@#{mounted_as}_secure_token"
-    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.hex(length/2))
   end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,26 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storagefog'
+
+CarrierWave.configure do |config|
+  config.fog_credentials = {
+    provider: 'AWS',
+    aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+    aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+    region: ENV['ap-northeast-1']
+  }
+
+  config.asset_host = ENV['S3_ASSET_HOST']
+
+  config.fog_directory =
+    case Rails.env
+    when 'production'; then'AMIRY_production'
+    when 'staging'; then 'AMIRY_staging'
+    when 'development'; then 'AMIRY_development'
+    else 'AMIRY_development'
+    end
+
+  config.storage = :file if Rails.env.test?
+end
+
+CarrierWave::SanitizedFile.sanitize_regexp = /[^[:word:]\.\-\+]/

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,14 +6,17 @@ require 'dotenv'
 Dotenv.overload
 
 CarrierWave.configure do |config|
-  config.fog_credentials = {
-    provider: 'AWS',
-    aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-    aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-    region: 'ap-northeast-1'
-  }
-
-  config.asset_host = ENV['S3_ASSET_HOST']
+  if Rails.env.test?
+    config.storage = :file
+  else
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1'
+    }
+    config.asset_host = ENV['S3_ASSET_HOST']
+  end
 
   config.fog_directory =
     case Rails.env
@@ -22,8 +25,6 @@ CarrierWave.configure do |config|
     when 'development'; then 'amiry-development'
     else 'amiry-development'
     end
-
-  config.storage = :file if Rails.env.test?
 end
 
 CarrierWave::SanitizedFile.sanitize_regexp = /[^[:word:]\.\-\+]/

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,23 +1,26 @@
 require 'carrierwave/storage/abstract'
 require 'carrierwave/storage/file'
-require 'carrierwave/storagefog'
+require 'carrierwave/storage/fog'
+require 'dotenv'
+
+Dotenv.overload
 
 CarrierWave.configure do |config|
   config.fog_credentials = {
     provider: 'AWS',
     aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
     aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-    region: ENV['ap-northeast-1']
+    region: 'ap-northeast-1'
   }
 
   config.asset_host = ENV['S3_ASSET_HOST']
 
   config.fog_directory =
     case Rails.env
-    when 'production'; then'AMIRY_production'
-    when 'staging'; then 'AMIRY_staging'
-    when 'development'; then 'AMIRY_development'
-    else 'AMIRY_development'
+    when 'production'; then'amiry-production'
+    when 'staging'; then 'amiry-staging'
+    when 'development'; then 'amiry-development'
+    else 'amiry-development'
     end
 
   config.storage = :file if Rails.env.test?

--- a/db/migrate/20180102064258_create_lecture_files.rb
+++ b/db/migrate/20180102064258_create_lecture_files.rb
@@ -1,0 +1,14 @@
+class CreateLectureFiles < ActiveRecord::Migration[5.1]
+  def change
+    create_table :lecture_files do |t|
+      t.integer    :user_id,    unsigned: true, null: false
+      t.integer    :lecture_id, unsigned: true, null: false
+      t.string     :name,                       null: false, default: ''
+      t.timestamps                              null: false
+    end
+
+    add_index :lecture_files, :user_id
+    add_index :lecture_files, :lecture_id
+    add_index :lecture_files, :name,      unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171229115409) do
+ActiveRecord::Schema.define(version: 20180102064258) do
 
   create_table "active_admin_comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "namespace"
@@ -136,6 +136,17 @@ ActiveRecord::Schema.define(version: 20171229115409) do
     t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["sender_id", "recipient_id"], name: "index_introductions_on_sender_id_and_recipient_id", unique: true
+  end
+
+  create_table "lecture_files", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "user_id", null: false, unsigned: true
+    t.integer "lecture_id", null: false, unsigned: true
+    t.string "name", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lecture_id"], name: "index_lecture_files_on_lecture_id"
+    t.index ["name"], name: "index_lecture_files_on_name", unique: true
+    t.index ["user_id"], name: "index_lecture_files_on_user_id"
   end
 
   create_table "lectures", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/docs/create_table.sql
+++ b/docs/create_table.sql
@@ -208,6 +208,19 @@ CREATE TABLE `lectures` (
   CONSTRAINT `fk_lectures_on_user_id` FOREIGN KEY(`user_id`) REFERENCES `users` (`id`) ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TABLE `lecture_files` (
+  `id`         BIGINT(20)  UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id`    BIGINT(20)  UNSIGNED NOT NULL,
+  `lecture_id` BIGINT(20)  UNSIGNED NOT NULL,
+  `name`       VARCHAR(64)          NOT NULL DEFAULT '',
+  `created_at` DATETIME             NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME             NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(`id`),
+  KEY(`user_id`),
+  KEY(`article_id`),
+  UNIQUE KEY(`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+
 CREATE TABLE `articles` (
   `id`         BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,  
   `user_id`    BIGINT(20) UNSIGNED NOT NULL,
@@ -239,8 +252,11 @@ CREATE TABLE `article_files` (
   `name`       VARCHAR(64)          NOT NULL DEFAULT '',
   `created_at` DATETIME             NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` DATETIME             NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY(`id`)
-)
+  PRIMARY KEY(`id`),
+  KEY(`user_id`),
+  KEY(`article_id`),
+  UNIQUE KEY(`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `messages`(
   `id`            BIGINT(20)  UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/spec/models/band_spec.rb
+++ b/spec/models/band_spec.rb
@@ -92,7 +92,8 @@ describe Band do
       context 'Uniqueness Validation.' do
         it 'is invalid with the name that has already been taken in the same circle.' do
           existing_band = create(:band)
-          band.circle_id, band.name = existing_band.circle_id, existing_band.name
+          band.circle_id = existing_band.circle_id
+          band.name = existing_band.name
           expect(band.valid?).to be_falsey
           expect(band.errors[:name]).to include('has already been taken')
         end

--- a/spec/models/live_spec.rb
+++ b/spec/models/live_spec.rb
@@ -90,7 +90,7 @@ describe Live do
       end
 
       it 'avaiable_seats_num method should return the same number as the difference between max_capacity and reservations_count' do
-        expect(live.available_seats_num).to eq (live.max_capacity - live.reservations_count)
+        expect(live.available_seats_num).to eq live.max_capacity - live.reservations_count
       end
     end
 


### PR DESCRIPTION
## WHY
 - ユーザーが投稿する写真や楽譜などのファイルをS3に転送するため。

## WHAT
 - `initializers/carrierwave.rb` を追加し、amazon access key や idを記載した。
 - `uploaders` ディレクトリのファイルに共通するメソッドなどを `base_uploader.rb` にし、他の`uploader` ファイルに`base_uploader` を継承させるようにした。
 - `lecture_files` テーブルを作成した。
 - 画像やファイルテーブルのモデルに、共通している定数やメソッドを `file_model_interface.rb` というモジュールで定義し、抽象度をあげた。
