### PR TITLE
手動デプロイスクリプトを追加

### DIFF
--- a/app/api/api_components/controllers/article_comments_controller.rb
+++ b/app/api/api_components/controllers/article_comments_controller.rb
@@ -1,7 +1,7 @@
 module APIComponents
   module Controllers
     class ArticleCommentsController < ApiController
-      desc 'Return all comments associated with the specific article.' do
+      desc 'Return all comments associated with the specific Article object.' do
         http_codes([
           { code: 200, message: 'Article Comment', model: Entities::ArticleComment }
         ])

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+kill -QUIT `cat /tmp/unicorn.pid`
+bundle exec unicorn_rails -c /home/umeki/AMIRY_API/config/unicorn.conf.rb -D -E production

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-kill -QUIT `cat /tmp/unicorn.pid`
+kill -QUIT `cat /home/umeki/AMIRY_API/tmp/pids/unicorn.pid`
 bundle exec unicorn_rails -c /home/umeki/AMIRY_API/config/unicorn.conf.rb -D -E production


### PR DESCRIPTION
## WHY
 - `capistrano` でのHotデプロイをすると、nginxがsocketファイルを読み込めないとエラーが発生してしまうため、手動デプロイという方法を取った。

## WHAT
 - `deploy.sh` を追加した。